### PR TITLE
Flink 1.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val root = project
     scalaVersion       := scala3Version,
     crossScalaVersions := Seq(scala3Version, scala213Version),
     libraryDependencies ++= flinkLibs ++ otherLibs ++ testingLibs,
-    publishingSettings
+    publishingSettings,
+    Test / parallelExecution := false
   )
 
 import ReleaseTransformations._

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,20 @@
 val scala213Version = "2.13.8"
-val scala3Version = "3.1.2"
+val scala3Version   = "3.1.2"
 
 val supportedScalaVersions = List(scala3Version)
 
-lazy val mavenSnapshots = "apache.snapshots" at "https://repository.apache.org/content/groups/snapshots"
+lazy val mavenSnapshots =
+  "apache.snapshots" at "https://repository.apache.org/content/groups/snapshots"
 
 resolvers ++= Seq(mavenSnapshots)
 
-val flinkVersion = "1.15.0"
+val flinkVersion = "1.16.1"
 
 val flinkLibs = Seq(
-   "org.apache.flink" % "flink-streaming-java" % flinkVersion,
-   "org.apache.flink" % "flink-core" % flinkVersion,
-   "org.apache.flink" % "flink-statebackend-rocksdb" % flinkVersion,
-   "org.apache.flink" % "flink-test-utils" % flinkVersion % Test
+  "org.apache.flink" % "flink-streaming-java"       % flinkVersion,
+  "org.apache.flink" % "flink-core"                 % flinkVersion,
+  "org.apache.flink" % "flink-statebackend-rocksdb" % flinkVersion,
+  "org.apache.flink" % "flink-test-utils"           % flinkVersion % Test
 )
 
 val otherLibs = Seq(
@@ -21,14 +22,14 @@ val otherLibs = Seq(
 )
 
 val testingLibs = Seq(
-  "org.scalatest" %% "scalatest" % "3.2.11" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.11" % Test
 )
 
 lazy val root = project
   .in(file("."))
   .settings(
-    name := "flink4s",
-    scalaVersion := scala3Version,
+    name               := "flink4s",
+    scalaVersion       := scala3Version,
     crossScalaVersions := Seq(scala3Version, scala213Version),
     libraryDependencies ++= flinkLibs ++ otherLibs ++ testingLibs,
     publishingSettings
@@ -37,8 +38,8 @@ lazy val root = project
 import ReleaseTransformations._
 
 lazy val publishingSettings = Seq(
-  organization := "com.ariskk",
-  organizationName := "ariskk",
+  organization         := "com.ariskk",
+  organizationName     := "ariskk",
   organizationHomepage := Some(url("http://ariskk.com/")),
   scmInfo := Some(
     ScmInfo(
@@ -48,15 +49,15 @@ lazy val publishingSettings = Seq(
   ),
   developers := List(
     Developer(
-      id    = "ariskk",
-      name  = "Aris Koliopoulos",
+      id = "ariskk",
+      name = "Aris Koliopoulos",
       email = "aris@ariskk.com",
-      url   = url("http://ariskk.com")
+      url = url("http://ariskk.com")
     )
   ),
   description := "Scala 3 wrapper for Apache Flink",
-  licenses := List("MIT" -> new URL("http://opensource.org/licenses/MIT")),
-  homepage := Some(url("https://github.com/ariskk/flink4s")),
+  licenses    := List("MIT" -> new URL("http://opensource.org/licenses/MIT")),
+  homepage    := Some(url("https://github.com/ariskk/flink4s")),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -2,5 +2,5 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.6")
 


### PR DESCRIPTION
Update to Flink 1.16.

The formatting changes to `build.sbt` are due to scalafmt being applied.